### PR TITLE
chore: require approval before merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,11 +23,10 @@ github:
     - gateway
     - plugin
   protected_branches:
-    # All protected branches in the YAML must be dictionary entries.
-    # Thus, if you only want to disable force push from a branch,
-    # you can construct a fake dictionary
     master:
-        foo: bar
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        required_approving_review_count: 1
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
This setup is already enabled in Java / Go plugin runner