### PR TITLE
fix:chown socket file to belong to nobody

### DIFF
--- a/apisix/runner/server/server.py
+++ b/apisix/runner/server/server.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 #
 
+import grp
 import os
 import socket
 
+from pwd import getpwnam
 from threading import Thread as NewThread
 from apisix.runner.server.handle import Handle as NewServerHandle
 from apisix.runner.server.protocol import Protocol as NewServerProtocol
@@ -82,6 +84,7 @@ class Server:
             os.remove(self.fd)
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.bind(self.fd)
+        os.chown(self.fd, getpwnam('nobody').pw_uid, grp.getgrnam('nobody').gr_gid)
         self.sock.listen(1024)
 
         self.logger = NewServerLogger(config.logging.level)


### PR DESCRIPTION
In order to solve [this bug](https://github.com/apache/apisix-python-plugin-runner/issues/53), the socket created by **apisix/runner/server/server.py** now belongs to `nobody` so apisix runners could write on it. 

I choose not to follow go plugin's `chmod` approach [here](https://discord.com/channels/888802512843456623/888802512843456626/1019874428991057920), for it is to permissive / dangerous and could lead to privilege escalation