### PR TITLE
Update PyYAML to 6.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 a6pluginprotos==0.2.1
 click==8.0.1
 minicache==0.0.1
-PyYAML==5.4.1
+PyYAML==6.0.3


### PR DESCRIPTION
PyYAML==5.4.1 does not build on Python 3.12+

This PR pins PyYAML to 6.0.3. ~The runner already uses yaml.load(..., Loader=yaml.FullLoader), which is compatible with PyYAML 6.x, so no code changes are required.~ 
The runner required using `safe_load` in config.py to be compatible with PyYaml 6.0.3. A new pull request, #68, has already been submitted to implement the change. 

This restores compatibility with current Python releases without changing runtime behavior