### PR TITLE
Use safe_load for reading YAML config file and upgrade flatbuffers dependency version

### DIFF
--- a/apisix/runner/server/config.py
+++ b/apisix/runner/server/config.py
@@ -120,7 +120,7 @@ class Config:
             exit(1)
 
         # reading config file
-        with open(cf_path, encoding=\"UTF-8\") as fs:
+        with open(cf_path, encoding="UTF-8") as fs:
             configs = yaml.safe_load(fs)
 
         # socket config

--- a/apisix/runner/server/config.py
+++ b/apisix/runner/server/config.py
@@ -120,8 +120,8 @@ class Config:
             exit(1)
 
         # reading config file
-        fs = open(cf_path, encoding="UTF-8")
-        configs = yaml.load(fs, Loader=yaml.FullLoader)
+        with open(cf_path, encoding=\"UTF-8\") as fs:
+            configs = yaml.safe_load(fs)
 
         # socket config
         socket = configs.get("socket", {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 a6pluginprotos==0.2.1
 click==8.0.1
 minicache==0.0.1
-PyYAML==5.4.1
+PyYAML==6.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ a6pluginprotos==0.2.1
 click==8.0.1
 minicache==0.0.1
 PyYAML==6.0.3
+flatbuffers==25.12.19


### PR DESCRIPTION
These are the final, minimal compatibility updates to make the `apisix-python-plugin-runner` compatible with modern python versions, 3.12+.
Upgrading PyYaml to version 6+ introduced a single breaking change, resolved by using `safe_load` in config.py. 